### PR TITLE
Added OptionParser::InvalidOption handler

### DIFF
--- a/bin/anycablebility
+++ b/bin/anycablebility
@@ -7,7 +7,7 @@ require 'anycablebility/cli/app'
 
 options = {}
 
-OptionParser.new do |cli|
+option_parser = OptionParser.new do |cli|
   cli.banner = <<~BANNER
     Anycablebility – AnyCable websocket server conformance tool.
 
@@ -37,7 +37,16 @@ OptionParser.new do |cli|
     puts Anycablebility::VERSION
     exit
   end
-end.parse!
+end
+
+begin
+  option_parser.parse!
+rescue OptionParser::InvalidOption => e
+  unknown_option = e.args.first
+  puts "This option looks unfamiliar: #{unknown_option}. A typo?"
+  puts 'Use `anycablebility --help` to list all available options.'
+  exit 1
+end
 
 app = Anycablebility::Cli::App.new
 


### PR DESCRIPTION
If you mistype an option, you get this:

    $ ./bin/anycablebility --taget ws://0.0.0.0:3030/cable

    ./bin/anycablebility:40:in `<main>': invalid option: --taget (OptionParser::InvalidOption)

Looks not so friendly, doesn't it?

This commit makes error message a bit more friendly and helpful.

    $ ./bin/anycablebility --taget ws://0.0.0.0:3030/cable

    This option looks unfamiliar: --taget. A typo?
    Use `anycablebility --help` to list all available options.